### PR TITLE
Update index.tsx

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -34,8 +34,8 @@ const FeatureList = [
     Svg: require('@site/static/img/feature_images/virtualization.svg').default,
     description: (
       <>
-        Extend or customize your website layout by reusing React. Docusaurus can
-        be extended while reusing the same header and footer.
+        A brief overview of the virtualization softwares supported by ParrotOS, such as VirtualBox and VMware, 
+        and how to install and configure them.
       </>
     ),
   },


### PR DESCRIPTION
On the website under the Virtualization Card, the default text given by Docusarus was written that is "Extend or customize your website layout by reusing React. Docusaurus can be extended while reusing the same header and footer." changed it to something related that is " A brief overview of the virtualization software supported by Parrot OS, such as VirtualBox and VMware, and how to install and configure them."